### PR TITLE
Allow dimension units to be specified (width and height)

### DIFF
--- a/Form/Extension/AceEditor/Type/AceEditorType.php
+++ b/Form/Extension/AceEditor/Type/AceEditorType.php
@@ -24,6 +24,9 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 class AceEditorType extends AbstractType
 {
+    private $defaultUnit = 'px';
+    private $units = array('%', 'in', 'cm', 'mm', 'em', 'ex', 'pt', 'pc', 'px');
+
     /**
      * Add the image_path option
      *
@@ -44,6 +47,21 @@ class AceEditorType extends AbstractType
             return $aceAttr;
         };
 
+        $defaultUnit = $this->defaultUnit;
+        $allowedUnits = $this->units;
+        $unitNormalizer = function(Options $options, $value) use ($defaultUnit, $allowedUnits) {
+            if(is_array($value)) {
+                return $value;
+            }
+            if(preg_match('/([0-9\.]+)\s*(' . join('|', $allowedUnits) . ')/', $value, $matchedValue)) {
+                $value = $matchedValue[1];
+                $unit = $matchedValue[2];
+            } else {
+                $unit = $defaultUnit;
+            }
+            return array('value' => $value, 'unit' => $unit);
+        };
+
         $resolver->setDefaults(array(
             'required' => false,
             'wrapper_attr' => array(),
@@ -61,8 +79,8 @@ class AceEditorType extends AbstractType
         ));
 
         $resolver->setAllowedTypes(array(
-            'width' => 'integer',
-            'height' => 'integer',
+            'width' => 'array',
+            'height' => 'array',
             'mode' => 'string',
             'font_size' => 'integer',
             'tab_size' => array('integer', 'null'),
@@ -75,6 +93,8 @@ class AceEditorType extends AbstractType
 
         $resolver->setNormalizers(array(
             'wrapper_attr' => $wrapperAttrNormalizer,
+            'width'        => $unitNormalizer,
+            'height'       => $unitNormalizer,
         ));
     }
 

--- a/Resources/views/Form/div_layout.html.twig
+++ b/Resources/views/Form/div_layout.html.twig
@@ -8,17 +8,19 @@
         var textarea = document.getElementById('{{ id }}'),
             editorElm = document.getElementById('{{ id }}_ace'),
             editor = ace.edit(editorElm),
-            width = {{ width }},
-            height = {{ height }};
+            width = {{ width.value }},
+            widthUnit = '{{ width.unit }}',
+            height = {{ height.value }},
+            heightUnit = '{{ height.unit }}';
 
         textarea.style.visibility = 'hidden';
-        textarea.style.width = width + 'px';
-        textarea.style.height = height + 'px';
+        textarea.style.width = width + widthUnit;
+        textarea.style.height = height + heightUnit;
 
         editorElm.style.fontSize='{{ font_size }}px';
-        editorElm.style.width = width + 'px';
-        editorElm.style.height = height + 'px';
-        editorElm.style.marginTop = -height + 'px';
+        editorElm.style.width = width + widthUnit;
+        editorElm.style.height = height + heightUnit;
+        editorElm.style.marginTop = -(height) + heightUnit;
 
         editor.setTheme("{{ theme }}");
         editor.getSession().setMode("{{ mode }}");


### PR DESCRIPTION
Allow width and height values to optionally be specified with a valid CSS unit (e.g. '10%' or '1000px').

If no unit is specified, it will default to 'px', thus the original behaviour is preserved.
