### PR TITLE
Fixed #10 "Error with Symfony 2.6"

### DIFF
--- a/Form/Extension/AceEditor/Type/AceEditorType.php
+++ b/Form/Extension/AceEditor/Type/AceEditorType.php
@@ -79,8 +79,8 @@ class AceEditorType extends AbstractType
         ));
 
         $resolver->setAllowedTypes(array(
-            'width' => 'array',
-            'height' => 'array',
+            'width' => array('integer', 'string', 'array'),
+            'height' => array('integer', 'string', 'array'),
             'mode' => 'string',
             'font_size' => 'integer',
             'tab_size' => array('integer', 'null'),


### PR DESCRIPTION
Hi,

This is my proposed patch for #10 
I loosen the validation rules to all allowed types, not only `array`, so no BC-break while it works with 2.6+