### PR TITLE
Fixed tests: Use Twig namespaced classes and removed usage deprecated interface

### DIFF
--- a/Tests/Twig/Extension/AceEditorExtensionTest.php
+++ b/Tests/Twig/Extension/AceEditorExtensionTest.php
@@ -20,11 +20,11 @@ class AceEditorExtensionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \Twig_Environment
+     * @return \Twig\Environment
      */
     private function getTwigEnvironment()
     {
-        return $this->getMockBuilder(\Twig_Environment::class)
+        return $this->getMockBuilder(\Twig\Environment::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/Twig/Extension/AceEditorExtensionTest.php
+++ b/Tests/Twig/Extension/AceEditorExtensionTest.php
@@ -52,8 +52,7 @@ class AceEditorExtensionTest extends \PHPUnit_Framework_TestCase
         $extension = $this->getExtension();
         $environment->method('hasExtension')->with(AssetExtension::class)->willReturn(false);
 
-        $extension->initRuntime($environment);
-        $extension->includeAceEditor();
+        $extension->includeAceEditor($environment);
     }
 
     public function testIncludeAceEditorTwig()
@@ -71,10 +70,9 @@ class AceEditorExtensionTest extends \PHPUnit_Framework_TestCase
             });
 
         $environment->method('getExtension')->with(AssetExtension::class)->willReturn($asset);
-        $extension->initRuntime($environment);
 
         ob_start();
-        $extension->includeAceEditor();
+        $extension->includeAceEditor($environment);
         $text = ob_get_clean();
         $this->assertSame(
             '<script src="//ace.js" charset="utf-8" type="text/javascript"></script><script src="//ext-language_tools.js" charset="utf-8" type="text/javascript"></script>',
@@ -82,7 +80,7 @@ class AceEditorExtensionTest extends \PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $extension->includeAceEditor();
+        $extension->includeAceEditor($environment);
         $text = ob_get_clean();
         $this->assertSame('', $text);
     }

--- a/Twig/Extension/AceEditorExtension.php
+++ b/Twig/Extension/AceEditorExtension.php
@@ -54,7 +54,7 @@ class AceEditorExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new TwigFunction('include_ace_editor', [$this, 'includeAceEditor'], ['is_safe' => ['html'], 'needs_environment' => true]),
+            'include_ace_editor' => new TwigFunction('include_ace_editor', [$this, 'includeAceEditor'], ['is_safe' => ['html'], 'needs_environment' => true]),
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.6",
-        "twig/twig": "^1.23|^2.0",
+        "twig/twig": "^1.34|^2.0",
         "symfony/framework-bundle": "^3.0|^4.0",
         "symfony/form": "^3.0|^4.0",
         "symfony/twig-bridge": "^3.0|^4.0",


### PR DESCRIPTION
This updates the branch of https://github.com/norzechowicz/aceeditor-bundle/pull/28 with `master` such that the tests pass.

Thanks to https://github.com/Sander-Toonen since he did all of the real work in this MR ;)