### PR TITLE
Add simple docker setup for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /vendor
 /var
+/.*.iid

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+ARG PHP_VERSION=8.1
+FROM php:${PHP_VERSION}-cli-alpine3.18
+
+COPY --link --from=composer:2 /usr/bin/composer /usr/bin/
+
+WORKDIR /src
+ENTRYPOINT []
+CMD ["sh"]

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@ ifneq ($(PHP_VERSION),)
 DOCKER_BUILD_ARGS += --build-arg PHP_VERSION=$(PHP_VERSION)
 endif
 
+DOCKER_RUN_IID_FILE = .docker_shell-$(PHP_VERSION).iid
+
 .PHONY: shell
 shell:
-	@docker build $(DOCKER_BUILD_ARGS) --iidfile .docker_shell.iid .
+	@docker build $(DOCKER_BUILD_ARGS) --iidfile $(DOCKER_RUN_IID_FILE) .
 	@docker run \
 		--init -it --rm \
 		--user $$(id -u):$$(id -g) \
 		-v $(PWD):/src \
-		$$(cat .docker_build.iid)
+		$$(cat $(DOCKER_RUN_IID_FILE))

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ ifneq ($(PHP_VERSION),)
 DOCKER_BUILD_ARGS += --build-arg PHP_VERSION=$(PHP_VERSION)
 endif
 
-DOCKER_RUN_IID_FILE = .docker_shell-$(PHP_VERSION).iid
+DOCKER_BUILD_IID_FILE = .docker-$(PHP_VERSION).iid
 
 .PHONY: shell
 shell:
-	@docker build $(DOCKER_BUILD_ARGS) --iidfile $(DOCKER_RUN_IID_FILE) .
+	@docker build $(DOCKER_BUILD_ARGS) --iidfile $(DOCKER_BUILD_IID_FILE) .
 	@docker run \
 		--init -it --rm \
 		--user $$(id -u):$$(id -g) \
 		-v $(PWD):/src \
-		$$(cat $(DOCKER_RUN_IID_FILE))
+		$$(cat $(DOCKER_BUILD_IID_FILE))

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifneq ($(PHP_VERSION),)
 DOCKER_BUILD_ARGS += --build-arg PHP_VERSION=$(PHP_VERSION)
 endif
 
-DOCKER_BUILD_IID_FILE = .docker-$(PHP_VERSION).iid
+DOCKER_BUILD_IID_FILE = .docker-php$(PHP_VERSION).iid
 
 .PHONY: shell
 shell:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+export DOCKER_BUILDKIT=1
+
+DOCKER_BUILD_ARGS ?=
+
+ifneq ($(PHP_VERSION),)
+DOCKER_BUILD_ARGS += --build-arg PHP_VERSION=$(PHP_VERSION)
+endif
+
+.PHONY: shell
+shell:
+	@docker build $(DOCKER_BUILD_ARGS) --iidfile .docker_shell.iid .
+	@docker run \
+		--init -it --rm \
+		--user $$(id -u):$$(id -g) \
+		-v $(PWD):/src \
+		$$(cat .docker_build.iid)


### PR DESCRIPTION
@norberttech I don't know if you'd be receptive to the idea of including this in the repository, but here goes :)

Requires a modern docker version (no min version check added though).
Run `make shell` to get a php cli container with composer for easy development.

By default php 8.1 is used since that's the version used for static analysis too, but you can also pass a different custom version with:
```
PHP_VERSION=8.3 make shell
```