### PR TITLE
Fix namespace for twig templates

### DIFF
--- a/src/Resources/config/form.xml
+++ b/src/Resources/config/form.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="ace_editor.form.resource">@NorbertTechSymfonyAceEditor/Form/div_layout.html.twig</parameter>
+        <parameter key="ace_editor.form.resource">@AceEditor/Form/div_layout.html.twig</parameter>
     </parameters>
     <services>
         <service id="ace_editor.form.type.ace_editor" class="AceEditorBundle\Form\Extension\AceEditor\Type\AceEditorType">

--- a/tests/DependencyInjection/Compiler/TwigFormPassTest.php
+++ b/tests/DependencyInjection/Compiler/TwigFormPassTest.php
@@ -36,7 +36,7 @@ class TwigFormPassTest extends TestCase
         $compiler->process($container);
 
         $this->assertSame(
-            ['@NorbertTechSymfonyAceEditor/Form/div_layout.html.twig', 'foo'],
+            ['@AceEditor/Form/div_layout.html.twig', 'foo'],
             $container->getParameter('twig.form.resources')
         );
     }


### PR DESCRIPTION
Missed a couple of spots after the namespace change.
This is sadly not found by current test coverage.