### PR TITLE
Remove support for php 8.2

### DIFF
--- a/.github/workflows/static-analyze.yml
+++ b/.github/workflows/static-analyze.yml
@@ -19,7 +19,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "8.2"
+          - "8.3"
         operating-system:
           - "ubuntu-latest"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
           - "lowest"
           - "highest"
         php-version:
-          - "8.2"
           - "8.3"
           - "8.4"
         operating-system:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check the table below to check if your PHP and symfony versions are supported.
 
 | PHP version(s)  | Symfony version(s)   | AceEditorBundle version  |
 | --------------- |----------------------| ------------------------------------------------------------------ |
-| >= 8.1          | ^5.4 \| ^6.4 \| ^7.1 | [^5.0](https://github.com/norberttech/aceeditor-bundle/tree/5.x)   |
+| >= 8.3          | ^5.4 \| ^6.4 \| ^7.0 | [^5.0](https://github.com/norberttech/aceeditor-bundle/tree/5.x)   |
 
 For older unsupported versions check the [releases](https://github.com/norberttech/aceeditor-bundle/releases) page.
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.3.0 || ~8.4.0",
         "twig/twig": "^2.0|^3.0",
         "symfony/framework-bundle": "^5.4|^6.0|^7.0",
         "symfony/form": "^5.4|^6.0|^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f99de70c514e305145a4c4f32bb9503e",
+    "content-hash": "7b20be7758882811b4c051088e345b87",
     "packages": [
         {
             "name": "psr/cache",
@@ -5222,12 +5222,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.2.0 || ~8.3.0 || ~8.4.0"
+        "php": "~8.3.0 || ~8.4.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
PHP 8.2 has reached EOL, remove support.

https://endoflife.date/php